### PR TITLE
Fix #5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required 
+dist: trusty 
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    on_success: always
+    on_failure: always
+#    recipients:
+#      - jane@doe
+env:
+  matrix:
+    - USE_DEB=true  ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - USE_DEB=true  ROS_DISTRO="indigo" PRERELEASE=true
+    - USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - USE_DEB=true  ROS_DISTRO="jade"   PRERELEASE=true
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script: 
+  - source .ci_config/travis.sh
+#  - source ./travis.sh  # Enable this when you have a package-local script 

--- a/aubo_kinematics/CMakeLists.txt
+++ b/aubo_kinematics/CMakeLists.txt
@@ -2,14 +2,14 @@ cmake_minimum_required(VERSION 2.8.3)
 project(aubo_kinematics)
 
 find_package(catkin REQUIRED COMPONENTS roscpp geometry_msgs moveit_core
-  moveit_ros_planning pluginlib tf_conversions)
+  moveit_kinematics moveit_ros_planning pluginlib tf_conversions)
 
 find_package(Boost REQUIRED COMPONENTS system)
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES aubo_i5_kin aubo_i5_moveit_plugin
-  CATKIN_DEPENDS roscpp geometry_msgs moveit_core moveit_ros_planning
+  CATKIN_DEPENDS roscpp geometry_msgs moveit_core moveit_kinematics moveit_ros_planning
     pluginlib tf_conversions
   DEPENDS boost
 )

--- a/aubo_kinematics/package.xml
+++ b/aubo_kinematics/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>moveit_core</build_depend>
+  <build_depend>moveit_kinematics</build_depend>
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>geometry_msgs</build_depend>
@@ -22,6 +23,7 @@
   <build_depend>boost</build_depend>
 
   <run_depend>moveit_core</run_depend>
+  <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>geometry_msgs</run_depend>

--- a/aubo_trajectory_filters/package.xml
+++ b/aubo_trajectory_filters/package.xml
@@ -10,13 +10,14 @@
      and moveit plugins for filtering robot trajectories.
    </p>
   </description>
-  <!--author email="sedwards@swri.org">Shaun Edwards</author-->
-  <!--author email="jnicho@swri.org">Jorge Nicho</author-->
-  <!--maintainer email="sedwards@swri.org">Shaun Edwards</maintainer-->
+  <author email="sedwards@swri.org">Shaun Edwards</author>
+  <author email="jnicho@swri.org">Jorge Nicho</author>
+  <author email="liuxin@our-robotics.com">liuxin</author>
+  <maintainer email="liuxin@our-robotics.com">liuxin</maintainer>
   <license>BSD</license>
-  <!--url type="website">http://ros.org/wiki/industrial_trajectory_filters</url-->
-  <!--url type="bugtracker">https://github.com/ros-industrial/industrial_core/issues</url-->
-  <!--url type="repository">https://github.com/ros-industrial/industrial_core</url-->
+  <url type="website">http://wiki.ros.org/aubo_trajectory_filters</url>
+  <url type="bugtracker">https://github.com/auboliuxin/aubo_robot/issues</url>
+  <url type="repository">https://github.com/auboliuxin/aubo_robot</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 


### PR DESCRIPTION
Please see https://github.com/ros-planning/moveit/pull/247 for the change in the upstream package. 
Sorry for the inconvenience.

Also adding is a config file for Travis CI that utilizes [industrial_ci](https://github.com/ros-industrial/industrial_ci).
- `industrial_ci` is a set of CI configs hosted on another repository and it frees you from maintaining CI configs. For each run of Travis your jobs fetch the latest config by git clone. For the detail please take a look at the readme in the link.
- To utilize CI, admins need to activate Travis for this repository. You can do so probably at somewhere like https://travis-ci.org/profile/auboliuxin